### PR TITLE
Add testing against Python 3.9

### DIFF
--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -1,0 +1,32 @@
+name: "Python 3.9"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit_tests:
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }} Unit Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [ '3.9' ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # fetch all tags and branches
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Install test dependencies
+        run: pip install .[test]
+        shell: bash
+      - name: Run Unit Tests
+        run: pytest tests
+        shell: bash


### PR DESCRIPTION
I'm trying this library on Python 3.9, and specifically interested in the `issubtype()` call - I haven't found a good alternative anywhere.

It's failing on a call to `issubclass()` with `typing.Optional` - so I wanted to see if the tests would pass here on Python 3.9 before digging deeper.
